### PR TITLE
Fix missing HOME var

### DIFF
--- a/component.yml.tpl
+++ b/component.yml.tpl
@@ -49,5 +49,7 @@ phases:
             - ansible-galaxy install -f -r requirements.yml || true
             # Wait for cloud-init
             - while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done
+            # Work around for missing environment
+            - export HOME=/root
             # Run playbook
             - ansible-playbook ${playbook_file}


### PR DESCRIPTION
This was necessary because the PHP composer installation requires a HOME var be set, and apparently it's not during some (or all) of the image builder routine. This might be a change in behavior to EC2 Image Builder.